### PR TITLE
Fix assertion

### DIFF
--- a/src/eadk/random.rs
+++ b/src/eadk/random.rs
@@ -70,7 +70,7 @@ pub fn get_random_decimal() -> f32 {
 
 /// Give a random number between start (included) and end (excluded).
 pub fn get_random_in_range(start: u32, stop: u32) -> u32 {
-    assert!(start <= stop, "Start must be smaller than stop");
+    assert!(start < stop, "Start must be smaller than stop");
     let mut random_u32 = unsafe { get_random_u32() };
     random_u32 %= stop - start;
     random_u32 += start;


### PR DESCRIPTION
In NumworksAppsRust/src/eadk/random.rs, if start == stop, random_u32 %= stop - start; will panic because it attempts to calculate the remainder with a divisor of zero. It should be changed into assert!(start < stop, "Start must be smaller than stop");